### PR TITLE
Low priority for the listener to pass in last position

### DIFF
--- a/DependencyInjection/M6WebApiExceptionExtension.php
+++ b/DependencyInjection/M6WebApiExceptionExtension.php
@@ -75,6 +75,7 @@ class M6WebApiExceptionExtension extends Extension
             [
                 'event' => 'kernel.exception',
                 'method' => 'onKernelException',
+                'priority' => '-100' // as the setresponse stop the exception propagation, this listener has to pass in last position
             ]
         );
 


### PR DESCRIPTION
Because when this listener catch an exception it stop its propagation with its event->setResponse
